### PR TITLE
Refactoring for CredentialProvider

### DIFF
--- a/src/main/java/com/stool/studentcooperationtools/domain/slide/controller/SlideApiController.java
+++ b/src/main/java/com/stool/studentcooperationtools/domain/slide/controller/SlideApiController.java
@@ -2,7 +2,6 @@ package com.stool.studentcooperationtools.domain.slide.controller;
 
 import com.google.api.client.auth.oauth2.Credential;
 import com.stool.studentcooperationtools.domain.api.ApiResponse;
-import com.stool.studentcooperationtools.domain.slide.Slide;
 import com.stool.studentcooperationtools.domain.slide.controller.response.SlideFindResponse;
 import com.stool.studentcooperationtools.domain.slide.service.SlideService;
 import com.stool.studentcooperationtools.security.credential.GoogleCredentialProvider;
@@ -13,10 +12,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.io.IOException;
-import java.security.GeneralSecurityException;
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -32,10 +27,10 @@ public class SlideApiController {
     }
 
     @PostMapping("/api/v1/presentation/{presentationId}/slides")
-    public ApiResponse<Boolean> updateSlides(@PathVariable("presentationId") Long presentationId, SessionMember member) throws GeneralSecurityException, IOException {
-        credentialProvider.initializeCredential(member.getProfile());
+    public ApiResponse<Boolean> updateSlides(@PathVariable("presentationId") Long presentationId, SessionMember member) {
         Credential credential = credentialProvider.getCredential();
         boolean result = slideService.updateSlides(presentationId, credential);
         return ApiResponse.of(HttpStatus.OK,result);
     }
+
 }

--- a/src/main/java/com/stool/studentcooperationtools/security/credential/GoogleCredentialProvider.java
+++ b/src/main/java/com/stool/studentcooperationtools/security/credential/GoogleCredentialProvider.java
@@ -1,5 +1,6 @@
 package com.stool.studentcooperationtools.security.credential;
 
+import com.google.api.client.auth.oauth2.BearerToken;
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow;
 import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
@@ -47,29 +48,13 @@ public class GoogleCredentialProvider {
         this.credentialsforupdateFilePath = credentialsforupdateFilePath;
     }
 
-    public void initializeCredential(String userId) throws IOException {
-        this.credential = authorize(userId);
+    public void initializeCredential(String accessToken) throws IOException {
+        this.credential = new Credential(BearerToken.authorizationHeaderAccessMethod())
+                .setAccessToken(accessToken);
     }
 
     public void initializeCredentialAdapter() throws IOException {
         this.credentialsAdapter = (HttpCredentialsAdapter) getHttpRequestInitializer();
-    }
-
-    private Credential authorize(String userId) {
-        try(InputStream in = GoogleCredentialProvider.class.getResourceAsStream(credentialsFilePath)) {
-
-            GoogleClientSecrets clientSecrets = GoogleClientSecrets.load(JSON_FACTORY, new InputStreamReader(in));
-
-            GoogleAuthorizationCodeFlow flow = new GoogleAuthorizationCodeFlow.Builder(
-                    new NetHttpTransport(), JSON_FACTORY, clientSecrets, SCOPES)
-                    .setDataStoreFactory(new FileDataStoreFactory(new java.io.File(tokensDirectoryPath)))
-                    .setAccessType("offline")
-                    .build();
-            LocalServerReceiver receiver = new LocalServerReceiver.Builder().setPort(8888).build();
-            return new AuthorizationCodeInstalledApp(flow, receiver).authorize(userId);
-        } catch (IOException e) {
-            throw new BeanCreationException(e.getMessage());
-        }
     }
 
     private HttpRequestInitializer getHttpRequestInitializer() {

--- a/src/main/java/com/stool/studentcooperationtools/security/credential/GoogleCredentialProvider.java
+++ b/src/main/java/com/stool/studentcooperationtools/security/credential/GoogleCredentialProvider.java
@@ -2,15 +2,9 @@ package com.stool.studentcooperationtools.security.credential;
 
 import com.google.api.client.auth.oauth2.BearerToken;
 import com.google.api.client.auth.oauth2.Credential;
-import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow;
-import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
-import com.google.api.client.extensions.java6.auth.oauth2.AuthorizationCodeInstalledApp;
-import com.google.api.client.extensions.jetty.auth.oauth2.LocalServerReceiver;
 import com.google.api.client.http.HttpRequestInitializer;
-import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.gson.GsonFactory;
-import com.google.api.client.util.store.FileDataStoreFactory;
 import com.google.api.services.drive.DriveScopes;
 import com.google.api.services.slides.v1.SlidesScopes;
 import com.google.auth.http.HttpCredentialsAdapter;
@@ -30,21 +24,13 @@ public class GoogleCredentialProvider {
     private final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
     private final List<String> SCOPES = Collections.singletonList(SlidesScopes.PRESENTATIONS);
 
-    private final String credentialsFilePath;
-
-    private final String tokensDirectoryPath;
-
     private final String credentialsforupdateFilePath;
 
     private Credential credential;
 
     private HttpCredentialsAdapter credentialsAdapter;
 
-    public GoogleCredentialProvider(@Value("${google.slides.credentials-file-path}") String credentialsFilePath,
-                                    @Value("${google.slides.tokens-directory-path}") String tokensDirectoryPath,
-                                    @Value("${google.slides.credentials-forupdate-file-path}") String credentialsforupdateFilePath) throws IOException {
-        this.credentialsFilePath = credentialsFilePath;
-        this.tokensDirectoryPath = tokensDirectoryPath;
+    public GoogleCredentialProvider(@Value("${google.slides.credentials-forupdate-file-path}") String credentialsforupdateFilePath) throws IOException {
         this.credentialsforupdateFilePath = credentialsforupdateFilePath;
     }
 


### PR DESCRIPTION
Slide API 활용을 위해 Credential을 얻어오는 방식을 
기존에 api 활용 시 따로 인증을 통해 얻어오기 -> 최초 로그인 시에 access를 같이 얻고 후에 자유롭게 활용할 수 있도록 변경

SlideServiceMockTest 최적화